### PR TITLE
fix : remove the wrong imports from tests

### DIFF
--- a/mailersend_test.go
+++ b/mailersend_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mailersend/mailersend-go/v1"
+	"github.com/mailersend/mailersend-go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/message_test.go
+++ b/message_test.go
@@ -3,7 +3,7 @@ package mailersend_test
 import (
 	"testing"
 
-	"github.com/mailersend/mailersend-go/v1"
+	"github.com/mailersend/mailersend-go"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
The go imports are wrong in the test. This breaks the `go mod tidy` with the error 
```
..... imports
        github.com/mailersend/mailersend-go tested by
        github.com/mailersend/mailersend-go.test imports
        github.com/mailersend/mailersend-go/v1: module github.com/mailersend/mailersend-go@latest found (v1.0.2), but does not contain package github.com/mailersend/mailersend-go/v1
```

This PR should fix the error and it should be possible to work with the library. Right now I have created my own fork of the repo to work on.