### PR TITLE
implement single email verification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ MailerSend Golang SDK
        - [Get a single template](#get-a-single-template)
        - [Delete a template](#delete-a-template)
     - [Email Verification](#email-verification)
-       - [Verify a single email][#verify-single-email]
+       - [Verify a single email](#verify-single-email)
        - [Get all email verification lists](#get-all-email-verification-lists)
        - [Get an email verification list](#get-an-email-verification-list)
        - [Create an email verification list](#create-an-email-verification-list)

--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,7 @@ MailerSend Golang SDK
        - [Get a single template](#get-a-single-template)
        - [Delete a template](#delete-a-template)
     - [Email Verification](#email-verification)
+       - [Verify a single email][#verify-single-email]
        - [Get all email verification lists](#get-all-email-verification-lists)
        - [Get an email verification list](#get-an-email-verification-list)
        - [Create an email verification list](#create-an-email-verification-list)
@@ -2083,6 +2084,39 @@ func main() {
 ```
 
 ## Email Verification
+
+### Verify a single email
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+	"log"
+	"time"
+
+	"github.com/mailersend/mailersend-go"
+)
+
+func main() {
+	// Create an instance of the mailersend client
+	ms := mailersend.NewMailersend(os.Getenv("MAILERSEND_API_KEY"))
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	options := &mailersend.SingleEmailVerificationOptions{
+		Email: "john@doe.com"
+	}
+
+	_, _, err := ms.EmailVerification.VerifySingle(ctx, options)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
 
 ### Get all email verification lists
 

--- a/email_verification.go
+++ b/email_verification.go
@@ -29,6 +29,10 @@ type resultEmailVerificationRoot struct {
 	Meta  Meta     `json:"meta"`
 }
 
+type resultSingleEmailVerification struct {
+	Status string `json:"status"`
+}
+
 type emailVerification struct {
 	Id                  string      `json:"id"`
 	Name                string      `json:"name"`
@@ -83,6 +87,10 @@ type GetEmailVerificationOptions struct {
 	EmailVerificationId string `url:"-"`
 	Page                int    `url:"page,omitempty"`
 	Limit               int    `url:"limit,omitempty"`
+}
+
+type SingleEmailVerificationOptions struct {
+	Email string `json:"email"`
 }
 
 func (s *EmailVerificationService) List(ctx context.Context, options *ListEmailVerificationOptions) (*emailVerificationRoot, *Response, error) {
@@ -175,6 +183,23 @@ func (s *EmailVerificationService) Verify(ctx context.Context, emailVerification
 	}
 
 	return root, res, nil
+}
+
+func (s *EmailVerificationService) VerifySingle(ctx context.Context, options *SingleEmailVerificationOptions) (*resultSingleEmailVerification, *Response, error) {
+	path := fmt.Sprintf("%s/verify", emailVerificationBasePath)
+
+	req, err := s.client.newRequest(http.MethodPost, path, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	verification := new(resultSingleEmailVerification)
+	res, err := s.client.do(ctx, req, verification)
+	if err != nil {
+		return nil, res, err
+	}
+
+	return verification, res, nil
 }
 
 func (s *EmailVerificationService) GetResults(ctx context.Context, options *GetEmailVerificationOptions) (*resultEmailVerificationRoot, *Response, error) {


### PR DESCRIPTION
Closes #78.

Note: I have not been able to test this yet, because I'm waiting for Mailersend Account Approval.

edit:
I have been able to test, and it works:
```go
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"github.com/mailersend/mailersend-go"
)

func main() {
	ms := mailersend.NewMailersend("<snip>")

	ctx := context.Background()
	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
	defer cancel()

	options := &mailersend.SingleEmailVerificationOptions{
		Email: "ds@sansec.io",
	}

	result, _, err := ms.EmailVerification.VerifySingle(ctx, options)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println(result.Status)
}
```

Output:
```
$ go run ./cmd/test
valid
```