### PR TITLE
Add optional language field to email send

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -351,7 +351,11 @@ func main() {
 	message.SetSubject(subject)
 	message.SetTemplateID("template-id")
 	message.SetSubstitutions(variables)
-	
+
+	// Optional: language code for the template (e.g. "de", "fr", "pt-BR").
+	// Supported: de, en, es, fr, it, lt, nl, pl, pt-BR. Only used with a template.
+	message.SetLanguage("pt-BR")
+
 	res, _ := ms.Email.Send(ctx, message)
 
 	fmt.Printf(res.Header.Get("X-Message-Id"))

--- a/email.go
+++ b/email.go
@@ -33,6 +33,7 @@ type Message struct {
 	Text        string       `json:"text,omitempty"`
 	HTML        string       `json:"html,omitempty"`
 	TemplateID  string       `json:"template_id,omitempty"`
+	Language    string       `json:"language,omitempty"`
 	SendAt      int64        `json:"send_at,omitempty"`
 	Tags        []string     `json:"tags,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
@@ -155,6 +156,12 @@ func (m *Message) SetText(text string) {
 // SetTemplateID - Set the template ID.
 func (m *Message) SetTemplateID(templateID string) {
 	m.TemplateID = templateID
+}
+
+// SetLanguage - Set the language used for the template (language code, e.g. "de", "pt-BR").
+// Only meaningful when a template is set; ignored for raw html/text sends.
+func (m *Message) SetLanguage(language string) {
+	m.Language = language
 }
 
 // Deprecated: SetSubstitutions - Set the template substitutions.

--- a/email_test.go
+++ b/email_test.go
@@ -3,6 +3,7 @@ package mailersend_test
 import (
 	"bufio"
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"os"
 	"testing"
@@ -10,6 +11,8 @@ import (
 	"github.com/mailersend/mailersend-go"
 	"github.com/stretchr/testify/assert"
 )
+
+const language = "pt-BR"
 
 const (
 	fromName  = "Your Name"
@@ -148,6 +151,29 @@ func TestTemplateMessage(t *testing.T) {
 	assert.Equal(t, templateID, message.TemplateID)
 	assert.Equal(t, personalization, message.Personalization)
 	assert.Equal(t, tags, message.Tags)
+}
+
+func TestTemplateLanguageMessage(t *testing.T) {
+	message := basicEmail()
+
+	message.SetTemplateID(templateID)
+	message.SetLanguage(language)
+
+	assert.Equal(t, language, message.Language)
+
+	body, err := json.Marshal(message)
+	assert.NoError(t, err)
+	assert.Contains(t, string(body), `"language":"pt-BR"`)
+}
+
+func TestLanguageOmittedWhenEmpty(t *testing.T) {
+	message := basicEmail()
+
+	assert.Empty(t, message.Language)
+
+	body, err := json.Marshal(message)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(body), `"language"`)
 }
 
 func TestFullMessage(t *testing.T) {


### PR DESCRIPTION
resolves [MSD-14489](https://linear.app/mailerlite/issue/MSD-14489/document-language-field-on-email-send-api-and-sdks)

Surfaces the new optional `language` field from the API's template-translations feature (MSD-14341) in the SDK.

### Changelist
- Add an optional `language` parameter to the email-send builder/params (e.g. `setLanguage("de")` / `.language("de")`), mirroring how `template_id` is handled.
- Include `language` in the request payload only when set; both single and bulk sends covered.
- README: add a short template + language example.
