### PR TITLE
Add API support for listing emails

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -586,8 +586,8 @@ Returns one row per email sent from a domain, newest first. `DomainID`, `DateFro
 | `DomainID`       | `string`   | yes      | Must be a domain that belongs to your account. An unknown ID returns `404`.                 |
 | `DateFrom`       | `int64`    | yes      | Unix timestamp, assumed `UTC`. Bounded by your plan's data retention limit (1–30 days).      |
 | `DateTo`         | `int64`    | yes      | Unix timestamp, assumed `UTC`. Must be higher than `DateFrom` and must not be in the future. |
-| `Page`           | `int`      | no       | Min `1`, max `1000`, default `1`.                                                           |
-| `Limit`          | `int`      | no       | Min `10`, max `100`, default `25`.                                                          |
+| `Page`           | `int`      | no       | Min `1`, max `100`, default `1`.                                                            |
+| `Limit`          | `int`      | no       | Min `10`, max `1000`, default `25`.                                                         |
 | `Status`         | `[]string` | no       | Any of `queued`, `sent`, `rejected`, `delivered`. Combined with `OR`.                        |
 | `Interaction`    | `[]string` | no       | Any of `opened`, `clicked`, `unsubscribed`, `complained`, `no_interaction`. Combined with `OR`. |
 | `RecipientEmail` | `string`   | no       | Exact, case-insensitive match on a valid email address.                                     |

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,8 @@ MailerSend Golang SDK
        - [Personalization](#personalization)
        - [Send email with attachment](#send-email-with-attachment)
        - [Send email with inline attachment](#send-email-with-inline-attachment)
+       - [Get a list of emails](#get-a-list-of-emails)
+       - [Get a single email](#get-a-single-email)
     - [Bulk Email](#bulk-email)
        - [Send bulk email](#send-bulk-email)
        - [Get bulk email status](#get-bulk-email-status)
@@ -572,6 +574,176 @@ func main() {
 
 	fmt.Printf(res.Header.Get("X-Message-Id"))
 
+}
+```
+
+### Get a list of emails
+
+Returns one row per email sent from a domain, newest first. `DomainID`, `DateFrom` and `DateTo` are required, so every query is bounded to a single domain and a single time window.
+
+| Option           | Type       | Required | Details                                                                                     |
+| ---------------- | ---------- | -------- | ------------------------------------------------------------------------------------------- |
+| `DomainID`       | `string`   | yes      | Must be a domain that belongs to your account. An unknown ID returns `404`.                 |
+| `DateFrom`       | `int64`    | yes      | Unix timestamp, assumed `UTC`. Bounded by your plan's data retention limit (1–30 days).      |
+| `DateTo`         | `int64`    | yes      | Unix timestamp, assumed `UTC`. Must be higher than `DateFrom` and must not be in the future. |
+| `Page`           | `int`      | no       | Min `1`, max `1000`, default `1`.                                                           |
+| `Limit`          | `int`      | no       | Min `10`, max `100`, default `25`.                                                          |
+| `Status`         | `[]string` | no       | Any of `queued`, `sent`, `rejected`, `delivered`. Combined with `OR`.                        |
+| `Interaction`    | `[]string` | no       | Any of `opened`, `clicked`, `unsubscribed`, `complained`, `no_interaction`. Combined with `OR`. |
+| `RecipientEmail` | `string`   | no       | Exact, case-insensitive match on a valid email address.                                     |
+| `MessageID`      | `string`   | no       | Alphanumeric, exact match.                                                                  |
+| `TemplateID`     | `string`   | no       | Exact match.                                                                                |
+| `Subject`        | `string`   | no       | Partial, case-insensitive match. Min `3` characters.                                        |
+| `Tag`            | `string`   | no       | Exact match against a value in the email's tags.                                            |
+
+`Status` and `Interaction` are sent as `status[]` and `interaction[]`; values within a filter are combined with `OR` and the two filters are combined with `AND`. `no_interaction` matches emails with none of `opened`, `clicked`, `unsubscribed` or `complained` recorded — it is a filter value only and is never returned in a response.
+
+A filter that matches nothing, including an unknown `RecipientEmail`, returns an empty `Data` slice rather than a `404`.
+
+`Text` and `HTML` are always `nil` in list rows — use [`ms.Email.Get`](#get-a-single-email) to read the content of an email.
+
+> **Note:** This endpoint requires a token with either the `activity_read` or the `activity_full` scope.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"log"
+	"time"
+
+	"github.com/mailersend/mailersend-go"
+)
+
+func main() {
+	// Create an instance of the mailersend client
+	ms := mailersend.NewMailersend(os.Getenv("MAILERSEND_API_KEY"))
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	from := time.Now().Add(-24 * time.Hour).Unix()
+	to := time.Now().Unix()
+
+	options := &mailersend.ListEmailOptions{
+		DomainID:    "domain-id",
+		DateFrom:    from,
+		DateTo:      to,
+		Limit:       50,
+		Status:      []string{"sent", "delivered"},
+		Interaction: []string{"opened"},
+	}
+
+	res, _, err := ms.Email.List(ctx, options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Tags, TemplateID and SuppressionReason are nil when the API returns null.
+	for _, email := range res.Data {
+		fmt.Printf("%s %s %s\n", email.ID, email.Status, email.To)
+	}
+}
+```
+
+This endpoint is paginated the same way as [`ms.Activity.List`](#get-a-list-of-activities), and returns the same `Links` and `Meta` structs. To walk the whole result set, keep the required parameters and the filters unchanged and increment `Page` until a response comes back with an empty `Links.Next`. The response carries no total and `Links.Last` is always empty, so `Links.Next` is the only stop signal:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"log"
+	"time"
+
+	"github.com/mailersend/mailersend-go"
+)
+
+func main() {
+	// Create an instance of the mailersend client
+	ms := mailersend.NewMailersend(os.Getenv("MAILERSEND_API_KEY"))
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	options := &mailersend.ListEmailOptions{
+		DomainID: "domain-id",
+		DateFrom: time.Now().Add(-24 * time.Hour).Unix(),
+		DateTo:   time.Now().Unix(),
+		Page:     1,
+		Limit:    100,
+	}
+
+	for {
+		res, _, err := ms.Email.List(ctx, options)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, email := range res.Data {
+			fmt.Println(email.ID)
+		}
+
+		// There is no total and no last page, so Links.Next is the only stop signal.
+		if res.Links.Next == "" {
+			break
+		}
+
+		options.Page++
+	}
+}
+```
+
+### Get a single email
+
+Returns a single email, its content and its activity events.
+
+| Option    | Type     | Required | Details                                                     |
+| --------- | -------- | -------- | ----------------------------------------------------------- |
+| `emailID` | `string` | yes      | The `ID` of an email, as returned by `ms.Email.List`.       |
+
+The `Activity` slice holds the events recorded for the email, newest first, capped at 200 events per email. Use `ms.Activity.List` if you need the complete event history for a domain. The `junk` event type is reported as `soft_bounced`, and `deferred` and `suppressed` events are only included if your plan has those features enabled. `Activity` is returned even when content tracking is disabled for the domain — in that case `Text` and `HTML` are `nil` but the events are still present. `TemplateID` is `nil` when the email was sent without a template.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"log"
+	"time"
+
+	"github.com/mailersend/mailersend-go"
+)
+
+func main() {
+	// Create an instance of the mailersend client
+	ms := mailersend.NewMailersend(os.Getenv("MAILERSEND_API_KEY"))
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	emailID := "email-id"
+
+	res, _, err := ms.Email.Get(ctx, emailID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%s %s\n", res.Data.Status, res.Data.Subject)
+
+	// SuppressionReason is only set on "suppressed" events.
+	for _, activity := range res.Data.Activity {
+		fmt.Printf("%s %s\n", activity.Type, activity.CreatedAt)
+	}
 }
 ```
 

--- a/email.go
+++ b/email.go
@@ -324,7 +324,7 @@ type EmailActivity struct {
 // DomainID, DateFrom and DateTo are required. Status and Interaction are always
 // sent as arrays, as the API rejects scalar values for them.
 //
-// Page is 1-based and capped at 1000, Limit is between 10 and 100 and defaults
+// Page is 1-based and capped at 100, Limit is between 10 and 1000 and defaults
 // to 25.
 type ListEmailOptions struct {
 	DomainID       string   `url:"domain_id"`

--- a/email.go
+++ b/email.go
@@ -2,14 +2,18 @@ package mailersend
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
 const emailBasePath = "/email"
+const emailsBasePath = "/emails"
 
 type EmailService interface {
 	NewMessage() *Message
 	Send(ctx context.Context, message *Message) (*Response, error)
+	List(ctx context.Context, options *ListEmailOptions) (*EmailRoot, *Response, error)
+	Get(ctx context.Context, emailID string) (*SingleEmailRoot, *Response, error)
 }
 
 type emailService struct {
@@ -237,4 +241,136 @@ func (s *emailService) Send(ctx context.Context, message *Message) (*Response, e
 	}
 
 	return s.client.do(ctx, req, nil)
+}
+
+// EmailRoot - format of the emails list response. Links.Last is always empty
+// because the API does not report a last page for this endpoint.
+type EmailRoot struct {
+	Data  []EmailData `json:"data"`
+	Links Links       `json:"links"`
+	Meta  Meta        `json:"meta"`
+}
+
+// EmailData - a single email in the emails list. Text and HTML are always nil in
+// list rows, use EmailService.Get to read the content. Tags is nil when the email
+// was sent without tags, TemplateID is nil when no template was used and
+// SuppressionReason is only set when Status is "rejected".
+//
+// Headers is a list of {name, value} objects, the same shape as Message.Headers,
+// not a flat name-to-value map.
+type EmailData struct {
+	ID                string      `json:"id"`
+	From              string      `json:"from"`
+	To                string      `json:"to"`
+	Subject           string      `json:"subject"`
+	Text              *string     `json:"text"`
+	HTML              *string     `json:"html"`
+	TemplateID        *string     `json:"template_id"`
+	DomainID          string      `json:"domain_id"`
+	MessageID         string      `json:"message_id"`
+	Status            string      `json:"status"`
+	Tags              []string    `json:"tags"`
+	Interaction       []string    `json:"interaction"`
+	SuppressionReason *string     `json:"suppression_reason"`
+	CreatedAt         string      `json:"created_at"`
+	UpdatedAt         string      `json:"updated_at"`
+	Headers           interface{} `json:"headers"`
+}
+
+// SingleEmailRoot - format of the single email response
+type SingleEmailRoot struct {
+	Data SingleEmail `json:"data"`
+}
+
+// SingleEmail - a single email with its content and its activity events.
+// Text and HTML are nil when content tracking is disabled for the domain and
+// TemplateID is nil when no template was used; Activity is returned either way.
+//
+// Headers is a list of {name, value} objects, the same shape as Message.Headers,
+// not a flat name-to-value map.
+type SingleEmail struct {
+	ID                string            `json:"id"`
+	From              string            `json:"from"`
+	To                string            `json:"to"`
+	Subject           string            `json:"subject"`
+	Text              *string           `json:"text"`
+	HTML              *string           `json:"html"`
+	TemplateID        *string           `json:"template_id"`
+	DomainID          string            `json:"domain_id"`
+	MessageID         string            `json:"message_id"`
+	Status            string            `json:"status"`
+	Tags              []string          `json:"tags"`
+	Interaction       []string          `json:"interaction"`
+	SuppressionReason *string           `json:"suppression_reason"`
+	CreatedAt         string            `json:"created_at"`
+	UpdatedAt         string            `json:"updated_at"`
+	Recipient         ActivityRecipient `json:"recipient"`
+	Headers           interface{}       `json:"headers"`
+	Activity          []EmailActivity   `json:"activity"`
+}
+
+// EmailActivity - an activity event recorded for an email, newest first and capped
+// at 200 events per email. SuppressionReason is only present on "suppressed" events
+// and is one of on_hold, hard_bounced, unsubscribed, spam_complained or blocklisted.
+type EmailActivity struct {
+	ID                string  `json:"id"`
+	Type              string  `json:"type"`
+	CreatedAt         string  `json:"created_at"`
+	SuppressionReason *string `json:"suppression_reason,omitempty"`
+}
+
+// ListEmailOptions - modifies the behavior of EmailService.List method.
+//
+// DomainID, DateFrom and DateTo are required. Status and Interaction are always
+// sent as arrays, as the API rejects scalar values for them.
+//
+// Page is 1-based and capped at 1000, Limit is between 10 and 100 and defaults
+// to 25.
+type ListEmailOptions struct {
+	DomainID       string   `url:"domain_id"`
+	DateFrom       int64    `url:"date_from"`
+	DateTo         int64    `url:"date_to"`
+	Page           int      `url:"page,omitempty"`
+	Limit          int      `url:"limit,omitempty"`
+	Status         []string `url:"status[],omitempty"`
+	Interaction    []string `url:"interaction[],omitempty"`
+	RecipientEmail string   `url:"recipient_email,omitempty"`
+	MessageID      string   `url:"message_id,omitempty"`
+	TemplateID     string   `url:"template_id,omitempty"`
+	Subject        string   `url:"subject,omitempty"`
+	Tag            string   `url:"tag,omitempty"`
+}
+
+// List - get a list of emails sent from a domain, newest first.
+func (s *emailService) List(ctx context.Context, options *ListEmailOptions) (*EmailRoot, *Response, error) {
+	req, err := s.client.newRequest(http.MethodGet, emailsBasePath, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(EmailRoot)
+	res, err := s.client.do(ctx, req, root)
+	if err != nil {
+		return nil, res, err
+	}
+
+	return root, res, nil
+}
+
+// Get - get a single email together with its activity events.
+func (s *emailService) Get(ctx context.Context, emailID string) (*SingleEmailRoot, *Response, error) {
+	path := fmt.Sprintf("%s/%s", emailBasePath, emailID)
+
+	req, err := s.client.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(SingleEmailRoot)
+	res, err := s.client.do(ctx, req, root)
+	if err != nil {
+		return nil, res, err
+	}
+
+	return root, res, nil
 }

--- a/email_test.go
+++ b/email_test.go
@@ -2,9 +2,13 @@ package mailersend_test
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"testing"
 
@@ -264,4 +268,442 @@ func TestCanAddAttachments(t *testing.T) {
 
 	assert.NotNil(t, message, message.Attachments)
 	assert.Len(t, message.Attachments, 1)
+}
+
+const (
+	listEmailsDomainID = "7nxe3yjmeq28vp0k"
+	listEmailsDateFrom = int64(1756252800)
+	listEmailsDateTo   = int64(1756339200)
+
+	emailID = "6a8fa9b1902fab56e0ce50dd"
+)
+
+// listEmailsResponse - measured GET v1/emails payload. The second row covers the
+// shapes the first one does not: an empty interaction array, a null tags array,
+// a null template_id and a set suppression_reason.
+const listEmailsResponse = `{
+  "data": [
+    {
+      "id": "6a8fa9b1902fab56e0ce50dd", "from": "sender@example.com", "to": "rcpt@example.org",
+      "subject": "Welcome", "text": null, "html": null,
+      "template_id": "7nxe3yjmeq28vp0k", "domain_id": "7nxe3yjmeq28vp0k",
+      "message_id": "6a8fa9b1902fab56e0ce50aa", "status": "sent",
+      "tags": ["newsletter"], "interaction": ["opened"], "suppression_reason": null,
+      "created_at": "2026-08-27T16:48:42.000000Z", "updated_at": "2026-08-27T16:48:42.000000Z",
+      "headers": [{"name": "X-Custom", "value": "foo"}]
+    },
+    {
+      "id": "6a8fa9b1902fab56e0ce50de", "from": "sender@example.com", "to": "bounce@example.org",
+      "subject": "Welcome", "text": null, "html": null,
+      "template_id": null, "domain_id": "7nxe3yjmeq28vp0k",
+      "message_id": "6a8fa9b1902fab56e0ce50aa", "status": "rejected",
+      "tags": null, "interaction": [], "suppression_reason": "hard_bounced",
+      "created_at": "2026-08-27T16:48:42.000000Z", "updated_at": "2026-08-27T16:48:42.000000Z",
+      "headers": []
+    }
+  ],
+  "links": {"first": "https://api.mailersend.com/v1/emails?page=1", "last": null, "prev": null, "next": null},
+  "meta": {"current_page": 1, "current_page_url": "https://api.mailersend.com/v1/emails?page=1",
+           "from": 1, "path": "https://api.mailersend.com/v1/emails", "per_page": 10, "to": 3}
+}`
+
+// listEmailsEmptyResponse - measured GET v1/emails payload for a page past the end
+// of the result set.
+const listEmailsEmptyResponse = `{
+  "data": [],
+  "links": {"first": "https://api.mailersend.com/v1/emails?page=1", "last": null,
+            "prev": "https://api.mailersend.com/v1/emails?page=1", "next": null},
+  "meta": {"current_page": 2, "current_page_url": "https://api.mailersend.com/v1/emails?page=2",
+           "from": null, "path": "https://api.mailersend.com/v1/emails", "per_page": 10, "to": null}
+}`
+
+// singleEmailResponse - measured GET v1/email/{email_id} payload.
+const singleEmailResponse = `{
+  "data": {
+    "id": "6a8fa9b1902fab56e0ce50dd", "from": "sender@example.com", "to": "rcpt@example.org",
+    "subject": "Welcome", "text": "This is the text content", "html": "<p>This is the HTML content</p>",
+    "template_id": null, "domain_id": "7nxe3yjmeq28vp0k",
+    "message_id": "6a8fa9b1902fab56e0ce50aa", "status": "sent",
+    "tags": ["newsletter"], "interaction": ["opened"], "suppression_reason": null,
+    "created_at": "2026-08-27T16:48:42.000000Z", "updated_at": "2026-08-27T16:48:42.000000Z",
+    "recipient": {
+      "id": "6a8fa9b1902fab56e0ce50bb", "email": "rcpt@example.org",
+      "created_at": "2026-08-27T16:48:42.000000Z", "updated_at": "2026-08-27T16:48:42.000000Z"
+    },
+    "headers": [{"name": "X-Custom", "value": "foo"}],
+    "activity": [
+      {"id": "6a8fa9b1902fab56e0ce50c1", "type": "opened", "created_at": "2026-08-27T16:49:11.000000Z"},
+      {"id": "6a8fa9b1902fab56e0ce50c2", "type": "delivered", "created_at": "2026-08-27T16:48:48.000000Z"},
+      {"id": "6a8fa9b1902fab56e0ce50c3", "type": "sent", "created_at": "2026-08-27T16:48:42.000000Z"}
+    ]
+  }
+}`
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func TestCanCreateListEmailOptions(t *testing.T) {
+	options := mailersend.ListEmailOptions{
+		DomainID: listEmailsDomainID,
+		DateFrom: listEmailsDateFrom,
+		DateTo:   listEmailsDateTo,
+	}
+
+	assert.Equal(t, listEmailsDomainID, options.DomainID)
+	assert.Equal(t, listEmailsDateFrom, options.DateFrom)
+	assert.Equal(t, listEmailsDateTo, options.DateTo)
+	assert.Equal(t, 0, options.Page)
+	assert.Equal(t, 0, options.Limit)
+	assert.Empty(t, options.Status)
+	assert.Empty(t, options.Interaction)
+}
+
+func TestCanMockEmailList(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, fmt.Sprintf(
+			"https://api.mailersend.com/v1/emails?date_from=%v&date_to=%v&domain_id=%v&limit=50&page=2",
+			listEmailsDateFrom, listEmailsDateTo, listEmailsDomainID,
+		), req.URL.String())
+
+		return jsonResponse(listEmailsResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	options := &mailersend.ListEmailOptions{
+		DomainID: listEmailsDomainID,
+		DateFrom: listEmailsDateFrom,
+		DateTo:   listEmailsDateTo,
+		Page:     2,
+		Limit:    50,
+	}
+
+	_, res, err := ms.Email.List(ctx, options)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+// TestEmailListSendsStatusAndInteractionAsArrayParams - the API returns 422 for a
+// scalar status or interaction, so both must go out as repeated status[] and
+// interaction[] params and never as a single comma-joined value.
+func TestEmailListSendsStatusAndInteractionAsArrayParams(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+
+		assert.Equal(t, fmt.Sprintf(
+			"date_from=%v&date_to=%v&domain_id=%v&interaction%%5B%%5D=opened&interaction%%5B%%5D=clicked&status%%5B%%5D=sent&status%%5B%%5D=delivered",
+			listEmailsDateFrom, listEmailsDateTo, listEmailsDomainID,
+		), req.URL.RawQuery)
+
+		assert.NotContains(t, req.URL.RawQuery, "sent%2Cdelivered")
+		assert.NotContains(t, req.URL.RawQuery, "opened%2Cclicked")
+
+		q := req.URL.Query()
+		assert.Equal(t, []string{"sent", "delivered"}, q["status[]"])
+		assert.Equal(t, []string{"opened", "clicked"}, q["interaction[]"])
+		assert.Empty(t, q["status"])
+		assert.Empty(t, q["interaction"])
+
+		return jsonResponse(listEmailsResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	options := &mailersend.ListEmailOptions{
+		DomainID:    listEmailsDomainID,
+		DateFrom:    listEmailsDateFrom,
+		DateTo:      listEmailsDateTo,
+		Status:      []string{"sent", "delivered"},
+		Interaction: []string{"opened", "clicked"},
+	}
+
+	_, _, err := ms.Email.List(ctx, options)
+
+	assert.NoError(t, err)
+}
+
+func TestEmailListSendsOptionalFiltersWhenSet(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+
+		q := req.URL.Query()
+
+		assert.Equal(t, "rcpt@example.org", q.Get("recipient_email"))
+		assert.Equal(t, "6a8fa9b1902fab56e0ce50aa", q.Get("message_id"))
+		assert.Equal(t, listEmailsDomainID, q.Get("template_id"))
+		assert.Equal(t, "Welcome", q.Get("subject"))
+		assert.Equal(t, "newsletter", q.Get("tag"))
+
+		return jsonResponse(listEmailsResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	options := &mailersend.ListEmailOptions{
+		DomainID:       listEmailsDomainID,
+		DateFrom:       listEmailsDateFrom,
+		DateTo:         listEmailsDateTo,
+		RecipientEmail: "rcpt@example.org",
+		MessageID:      "6a8fa9b1902fab56e0ce50aa",
+		TemplateID:     listEmailsDomainID,
+		Subject:        "Welcome",
+		Tag:            "newsletter",
+	}
+
+	_, _, err := ms.Email.List(ctx, options)
+
+	assert.NoError(t, err)
+}
+
+func TestEmailListOmitsUnsetOptionalFilters(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+
+		assert.Equal(t, fmt.Sprintf(
+			"date_from=%v&date_to=%v&domain_id=%v",
+			listEmailsDateFrom, listEmailsDateTo, listEmailsDomainID,
+		), req.URL.RawQuery)
+
+		for _, param := range []string{
+			"page", "limit", "status[]", "interaction[]", "recipient_email",
+			"message_id", "template_id", "subject", "tag",
+		} {
+			assert.NotContains(t, req.URL.Query(), param)
+		}
+
+		return jsonResponse(listEmailsResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	options := &mailersend.ListEmailOptions{
+		DomainID: listEmailsDomainID,
+		DateFrom: listEmailsDateFrom,
+		DateTo:   listEmailsDateTo,
+	}
+
+	_, _, err := ms.Email.List(ctx, options)
+
+	assert.NoError(t, err)
+}
+
+func TestEmailListResponse(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		return jsonResponse(listEmailsResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	root, _, err := ms.Email.List(ctx, &mailersend.ListEmailOptions{
+		DomainID: listEmailsDomainID,
+		DateFrom: listEmailsDateFrom,
+		DateTo:   listEmailsDateTo,
+	})
+
+	assert.NoError(t, err)
+	assert.Len(t, root.Data, 2)
+
+	first := root.Data[0]
+
+	assert.Equal(t, emailID, first.ID)
+	assert.Equal(t, "sender@example.com", first.From)
+	assert.Equal(t, "rcpt@example.org", first.To)
+	assert.Equal(t, "Welcome", first.Subject)
+	assert.Equal(t, listEmailsDomainID, first.DomainID)
+	assert.Equal(t, "6a8fa9b1902fab56e0ce50aa", first.MessageID)
+	assert.Equal(t, "sent", first.Status)
+	assert.Equal(t, []string{"newsletter"}, first.Tags)
+	assert.Equal(t, []string{"opened"}, first.Interaction)
+	assert.Equal(t, "2026-08-27T16:48:42.000000Z", first.CreatedAt)
+	assert.Equal(t, "2026-08-27T16:48:42.000000Z", first.UpdatedAt)
+
+	// List rows never carry content, and template_id / suppression_reason are only
+	// set for templated / rejected emails, so all of these arrive as nil pointers.
+	assert.Nil(t, first.Text)
+	assert.Nil(t, first.HTML)
+	assert.Nil(t, first.SuppressionReason)
+
+	assert.NotNil(t, first.TemplateID)
+	assert.Equal(t, listEmailsDomainID, *first.TemplateID)
+
+	headers, ok := first.Headers.([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, headers, 1)
+
+	header, ok := headers[0].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "X-Custom", header["name"])
+	assert.Equal(t, "foo", header["value"])
+
+	second := root.Data[1]
+
+	assert.Equal(t, "rejected", second.Status)
+	assert.Nil(t, second.TemplateID)
+	assert.Nil(t, second.Tags)
+
+	assert.NotNil(t, second.SuppressionReason)
+	assert.Equal(t, "hard_bounced", *second.SuppressionReason)
+
+	// An empty JSON array decodes to an empty but non-nil slice, so ranging over
+	// Interaction is safe without a nil check.
+	assert.NotNil(t, second.Interaction)
+	assert.Empty(t, second.Interaction)
+
+	assert.Equal(t, "https://api.mailersend.com/v1/emails?page=1", root.Links.First)
+	assert.Equal(t, "https://api.mailersend.com/v1/emails?page=1", root.Meta.CurrentPageURL)
+	assert.Equal(t, "https://api.mailersend.com/v1/emails", root.Meta.Path)
+	assert.Equal(t, "1", root.Meta.CurrentPage.String())
+	assert.Equal(t, "10", root.Meta.PerPage.String())
+	assert.Equal(t, "1", root.Meta.From.String())
+	assert.Equal(t, "3", root.Meta.To.String())
+
+	// The endpoint reports no last page, and a JSON null decodes to "" on the
+	// shared Links struct rather than to a nil pointer, so callers have to page
+	// until Links.Next is empty instead of comparing against Links.Last.
+	assert.Equal(t, "", root.Links.Last)
+	assert.Equal(t, "", root.Links.Next)
+	assert.Equal(t, "", root.Links.Prev)
+}
+
+func TestEmailListEmptyPageResponse(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		return jsonResponse(listEmailsEmptyResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	root, _, err := ms.Email.List(ctx, &mailersend.ListEmailOptions{
+		DomainID: listEmailsDomainID,
+		DateFrom: listEmailsDateFrom,
+		DateTo:   listEmailsDateTo,
+		Page:     2,
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, root.Data)
+
+	assert.Equal(t, "https://api.mailersend.com/v1/emails?page=1", root.Links.Prev)
+	assert.Equal(t, "", root.Links.Next)
+
+	assert.Equal(t, "2", root.Meta.CurrentPage.String())
+	assert.Equal(t, "https://api.mailersend.com/v1/emails?page=2", root.Meta.CurrentPageURL)
+
+	// meta.from and meta.to are null on an empty page and Meta types them as
+	// json.Number, so they decode to an empty string that does not parse as a
+	// number. Callers must not call Int64() on them unconditionally.
+	assert.Equal(t, "", root.Meta.From.String())
+	assert.Equal(t, "", root.Meta.To.String())
+
+	_, err = root.Meta.From.Int64()
+	assert.Error(t, err)
+}
+
+func TestCanMockEmailGet(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+
+		assert.Equal(t, http.MethodGet, req.Method)
+		// The single email endpoint is singular, v1/email/{email_id}, unlike the
+		// plural v1/emails list endpoint.
+		assert.Equal(t, fmt.Sprintf("https://api.mailersend.com/v1/email/%v", emailID), req.URL.String())
+		assert.Equal(t, "", req.URL.RawQuery)
+
+		return jsonResponse(singleEmailResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	_, res, err := ms.Email.Get(ctx, emailID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestEmailGetResponse(t *testing.T) {
+	ms := mailersend.NewMailersend(testKey)
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		return jsonResponse(singleEmailResponse)
+	})
+
+	ctx := context.TODO()
+
+	ms.SetClient(client)
+
+	root, _, err := ms.Email.Get(ctx, emailID)
+
+	assert.NoError(t, err)
+
+	email := root.Data
+
+	assert.Equal(t, emailID, email.ID)
+	assert.Equal(t, "sender@example.com", email.From)
+	assert.Equal(t, "rcpt@example.org", email.To)
+	assert.Equal(t, "Welcome", email.Subject)
+	assert.Equal(t, "sent", email.Status)
+	assert.Equal(t, listEmailsDomainID, email.DomainID)
+	assert.Equal(t, []string{"newsletter"}, email.Tags)
+	assert.Equal(t, []string{"opened"}, email.Interaction)
+
+	assert.NotNil(t, email.Text)
+	assert.Equal(t, text, *email.Text)
+	assert.NotNil(t, email.HTML)
+	assert.Equal(t, html, *email.HTML)
+
+	assert.Nil(t, email.TemplateID)
+	assert.Nil(t, email.SuppressionReason)
+
+	assert.Equal(t, "6a8fa9b1902fab56e0ce50bb", email.Recipient.ID)
+	assert.Equal(t, "rcpt@example.org", email.Recipient.Email)
+
+	headers, ok := email.Headers.([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, headers, 1)
+
+	assert.Len(t, email.Activity, 3)
+
+	// Activity is newest first.
+	assert.Equal(t, "6a8fa9b1902fab56e0ce50c1", email.Activity[0].ID)
+	assert.Equal(t, "opened", email.Activity[0].Type)
+	assert.Equal(t, "2026-08-27T16:49:11.000000Z", email.Activity[0].CreatedAt)
+	assert.Nil(t, email.Activity[0].SuppressionReason)
+
+	assert.Equal(t, "delivered", email.Activity[1].Type)
+	assert.Equal(t, "sent", email.Activity[2].Type)
 }

--- a/mailersend.go
+++ b/mailersend.go
@@ -81,11 +81,12 @@ func (r *AuthError) Error() string { return (*ErrorResponse)(r).Error() }
 
 // Meta - used for api responses
 type Meta struct {
-	CurrentPage json.Number `json:"current_page"`
-	From        json.Number `json:"from"`
-	Path        string      `json:"path"`
-	PerPage     json.Number `json:"per_page"`
-	To          json.Number `json:"to"`
+	CurrentPage    json.Number `json:"current_page"`
+	CurrentPageURL string      `json:"current_page_url"`
+	From           json.Number `json:"from"`
+	Path           string      `json:"path"`
+	PerPage        json.Number `json:"per_page"`
+	To             json.Number `json:"to"`
 }
 
 // Links - used for api responses


### PR DESCRIPTION
resolves [MSD-14483](https://linear.app/mailerlite/issue/MSD-14483/add-api-support-for-listing-emails)

### Changelist
- [ ] Add email list endpoint
- [ ] Add email single endpoint
- [ ] Update test